### PR TITLE
fix: request https instead

### DIFF
--- a/bin/pkg-bump.js
+++ b/bin/pkg-bump.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const fs = require("fs")
-const http = require("http")
+const https = require("https")
 const path = require("path")
 const file = path.resolve("package.json")
 
@@ -40,8 +40,8 @@ if (!names.length) {
 let latest = {}
 let remaining = names.length
 for (let name of names) {
-	let url = `http://registry.npmjs.org/${name}/latest`
-	http.get(url, res => {
+	let url = `https://registry.npmjs.org/${name}/latest`
+	https.get(url, res => {
 		let bufs = []
 		res.on("error", callback)
 			.on("data", data => bufs.push(data))


### PR DESCRIPTION
I was getting a JSON.parse error, because I guess the http endpoints can sometimes redirect to the https endpoints with an empty 301 response.